### PR TITLE
[Fix] model의 label url 분리하고, model 초기화 위치 변경한다.

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -1,0 +1,21 @@
+from model.model import classifier
+
+# dependencies.py
+class SingletonModel:
+    _instance = None
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            cls._instance = cls._load_model()
+            print("AI Model Loaded")
+        return cls._instance
+
+    @staticmethod
+    def _load_model():
+        # 모델 로드 로직
+        model = classifier()
+        return model
+
+def get_model():
+    return SingletonModel.get_instance()

--- a/model/model.py
+++ b/model/model.py
@@ -5,14 +5,16 @@ import clip
 import json
 import requests
 import io
+import os
 from typing import List
 
 class classifier():
   def __init__(self):
     self.device = torch.device("cuda:1" if torch.cuda.is_available() else "cpu")
     self.model, self.preprocess = clip.load("RN50")
-    labels_url = 'https://storage.googleapis.com/download.tensorflow.org/data/imagenet_class_index.json'
-    self.labels = json.loads(requests.get(labels_url).text)
+
+    LABEL_URL = os.getenv('LABEL_URL')  
+    self.labels = json.loads(requests.get(LABEL_URL).text)
 	
     self.model.to(self.device).eval()
 


### PR DESCRIPTION
## ✏ Summary
- .env에 model의 label url을 분리함.
- 기존에 요청을 처리할 때마다 model을 초기화했던 방식에서 서버를 가동할 때 model의 단일 인스턴스를 생성하고 요청을 처리할 때 load하는 방식으로 변경.
